### PR TITLE
Introduction of Argparse and modification of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,31 @@
 # LSTMVAE
 LSTMVAE implemented with chainer.
-Codes are based on 
+
+This code is for Python 3.
+
+Codes are based on
 [Generating sentences from continuous space.](https://arxiv.org/abs/1511.06349)
 written by Samuel R. Bowman in 2015.
 
-Models can be downloaded from 
-./bunseki/sent/model/download_model.sh
+## Pre-trained Model
+Models can be downloaded from
+```
+. ./src/each_case/prof/model/download_model.sh
+```
+If the file name is incorrect, please rename it to "biconcatlstm_vae_kl_prof_29_l200.npz".
 
-Training data are in 
-./bunseki/sent/prof16000fixed_longcut.txt
-
-training and test can be executed from 
-./bunseki/sampleTrainTest.py
-
+Test can be executed by
+```
+python ./src/each_case/sampleTrainTest.py
+```
 Hyperparameters are also set there.
+
+## Train and Test
+Training data are in
+.src/each_case/prof/prof16000fixed_longcut.txt
+
+Training can be executed by
+```
+python ./src/each_case/sampleTrainTest.py --train
+```
+Then, test can be executed as above. Hyperparameters are also set there.

--- a/src/each_case/sampleTrainTest.py
+++ b/src/each_case/sampleTrainTest.py
@@ -3,6 +3,8 @@ sys.path.append("../")
 from BiVarConcatLSTM import train,test
 from AddVaeConcat import testAdd
 
+import argparse
+
 class Args():
     def __init__(self,dataname,train=True):
         self.source ="./{}/prof16000fixed_longcut.txt".format(dataname)
@@ -53,5 +55,13 @@ def sampleTest():
 
 
 if __name__=="__main__":
-    # sampleTrain()
-    sampleTest()
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument("--train",
+                        help="train mode",
+                        action="store_true")
+    args = parser.parse_args()
+
+    if args.train:
+        sampleTrain()
+    else:
+        sampleTest()


### PR DESCRIPTION
- Since it does not work in Python 2, add a message that it is Python 3 code.
- Fixed incorrect directory structure in README.
- Add "argparse" for training (now, it is not necessary to rewrite the code for training)